### PR TITLE
Makefile empty repo fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,14 @@ SRSRAN_DOCKER_PATH = $(SRSRAN_REPO_DIR)/docker/docker-compose.yml
 # checks that the repository directory exists and clones open5gs if it does not
 .phony: srsran-check-clone
 srsran-check-clone:
-ifeq ($(wildcard $(SRSRAN_REPO_DIR))/*,)
+ifeq ($(wildcard $(SRSRAN_REPO_DIR)),)
+# the repository directory does not exist
 	@echo "Cloning repository $(SRSRAN_REPO_URL)..."
 	git clone $(SRSRAN_REPO_URL) $(SRSRAN_REPO_DIR)
+else ifeq ($(wildcard $(SRSRAN_REPO_DIR)/*),)
+# the repository directory is empty
+		@echo "Cloning repository $(SRSRAN_REPO_URL)..."
+		git clone $(SRSRAN_REPO_URL) $(SRSRAN_REPO_DIR)
 else
 	@echo "Repository $(REPO_DIR) already exists."
 endif

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SRSRAN_DOCKER_PATH = $(SRSRAN_REPO_DIR)/docker/docker-compose.yml
 # checks that the repository directory exists and clones open5gs if it does not
 .phony: srsran-check-clone
 srsran-check-clone:
-ifeq ($(wildcard $(SRSRAN_REPO_DIR)),)
+ifeq ($(wildcard $(SRSRAN_REPO_DIR))/*,)
 	@echo "Cloning repository $(SRSRAN_REPO_URL)..."
 	git clone $(SRSRAN_REPO_URL) $(SRSRAN_REPO_DIR)
 else


### PR DESCRIPTION
This changes the make command, so it does not fail when the srsRAN_Project folder is empty. 

The make rule first checks if the directory exists, and then checks if it is empty. 